### PR TITLE
TypeError: Converting circular structure to JSON

### DIFF
--- a/src/Recorder.ts
+++ b/src/Recorder.ts
@@ -486,13 +486,13 @@ export class Recorder {
     response?: ResponseRecording
   ) {
     // Poor-man's clone for immutability
-    const request = JSON.parse(JSON.stringify(interceptedRequest));
-    const { body, headers, method, options } = request;
+    const headers = JSON.parse(JSON.stringify(interceptedRequest.headers));
+    const { body, method, options } = interceptedRequest;
     const href = this.getHrefFromOptions(options);
     const url = new URL(href, true);
 
     // fThis is redundant with `href`, so why should we keep it?
-    delete request.headers.host;
+    delete headers.host;
 
     // Remove ephemeral ports from superagent testing
     // ! user-agent can be "..." or ["..."]


### PR DESCRIPTION
This shouldn't be used this way, when all I'm looking to do is have a mutable version of `headers`.

https://github.com/ericclemmons/node-recorder/blob/186efb87288637f79eea99e87496d09830702278/src/Recorder.ts#L488-L489